### PR TITLE
Add epinowcast/actions/install-cmdstan + pgdown as env object

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,6 +12,10 @@ on:
   merge_group:
   workflow_dispatch:
 
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref }}
+    cancel-in-progress: true
+
 name: R-CMD-check
 
 jobs:
@@ -36,25 +40,7 @@ jobs:
       NOT_CRAN: true
       
     steps:
-      - name: cmdstan env vars
-        run: |
-          echo "CMDSTAN_PATH=${HOME}/.cmdstan" >> $GITHUB_ENV
-        shell: bash
-
-      - uses: n1hility/cancel-previous-runs@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
-
       - uses: actions/checkout@v4
-        
-      - name: Install cmdstan Linux system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev || true
-          sudo apt-get install -y openmpi-bin openmpi-common libopenmpi-dev || true
-          sudo apt-get install -y libpng-dev || true
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -71,11 +57,10 @@ jobs:
           needs: check
 
       - name: Install cmdstan
-        run: |
-          print(list.files("C:/rtools43"))
-          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
-        shell: Rscript {0}
+        uses: epinowcast/actions/install-cmdstan@v1
+        with:
+          cmdstan-version: 'latest'
+          num-cores: 2
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: ['release', 'main']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+  
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -16,12 +20,6 @@ jobs:
       packages: write
 
     steps:
-
-      - name: Cancel previous builds if present
-        uses: n1hility/cancel-previous-runs@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-        
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -38,14 +38,21 @@ jobs:
           needs: website
 
       - name: Install cmdstan
-        run: |
-          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
-        shell: Rscript {0}
+        uses: epinowcast/actions/install-cmdstan@v1
+        with:
+          cmdstan-version: 'latest'
+          num-cores: 2
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
+
+      - name: Upload website
+        uses: actions/upload-artifact@v4
+        with:
+          name: website
+          retention-days: 5
+          path: docs
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
   merge_group:
 
+
 name: test-coverage
 
 jobs:
@@ -31,10 +32,10 @@ jobs:
           needs: coverage
 
       - name: Install cmdstan
-        run: |
-          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)
-        shell: Rscript {0}
+        uses: epinowcast/actions/install-cmdstan@v1
+        with:
+          cmdstan-version: 'latest'
+          num-cores: 2
 
       - name: Test coverage
         run: covr::codecov(quiet = FALSE)


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR is not linked to an issue. It overhauls the current CI to better match practice in `epinowcast` (mostly this is using our `cmdstan` action which has caching to speed up builds of CI) in order to begin looking at the issue with the `pkgdown` docs. With the same aim in mind it also adds saving the built website as an enviroment object (which is not standard `epinowcast` practice but should imo).

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
