### PR TITLE
Issue 134: Drop rstan dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,8 +42,7 @@ Suggests:
     gt,
     dplyr,
     knitr,
-    roxyglobals,
-    rstan
+    roxyglobals
 Remotes:
     stan-dev/cmdstanr,
     Rdatatable/data.table,

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -1,7 +1,8 @@
 expect_convergence <- function(fit, per_dts = 0.05, treedepth = 10,
                                rhat = 1.05) {
-  div <- subset(brms::nuts_params(fit), Parameter == "divergent__")
-  per_divergent_transitions <- mean(div$Value)
+  np <- brms::nuts_params(fit)
+  indices <- np$Parameter == "divergent__"
+  per_divergent_transitions <- mean(np[indices, ]$Value)
   max_treedepth <- brms::control_params(fit)$max_treedepth
   max_rhat <- max(brms::rhat(fit))
   testthat::expect_lt(per_divergent_transitions, per_dts)

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -1,7 +1,8 @@
 expect_convergence <- function(fit, per_dts = 0.05, treedepth = 10,
                                rhat = 1.05) {
-  per_divergent_transitions <- mean(rstan::get_divergent_iterations(fit$fit))
-  max_treedepth <- rstan::get_num_max_treedepth(fit$fit)
+  div <- subset(brms::nuts_params(fit), Parameter == "divergent__")
+  per_divergent_transitions <- mean(div$Value)
+  max_treedepth <- brms::control_params(fit)$max_treedepth
   max_rhat <- max(brms::rhat(fit))
   testthat::expect_lt(per_divergent_transitions, per_dts)
   testthat::expect_lt(max_treedepth, treedepth)

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -1,13 +1,10 @@
-get_sampler_params <- function(fit) {
-  sp <- lapply(fit$fit@sim$samples, function(x) attr(x, "sampler_params"))
-  do.call(rbind, sp)
-}
-
 expect_convergence <- function(fit, per_dts = 0.05, treedepth = 10,
                                rhat = 1.05) {
-  np <- get_sampler_params(fit)
-  per_divergent_transitions <- mean(np$divergent__)
-  max_treedepth <- max(np$treedepth__)
+  np <- brms::nuts_params(fit)
+  divergent_indices <- np$Parameter == "divergent__"
+  per_divergent_transitions <- mean(np[divergent_indices, ]$Value)
+  treedepth_indices <- np$Parameter == "treedepth__"
+  max_treedepth <- max(np[treedepth_indices, ]$Value)
   max_rhat <- max(brms::rhat(fit))
   testthat::expect_lt(per_divergent_transitions, per_dts)
   testthat::expect_lt(max_treedepth, treedepth)

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -1,9 +1,13 @@
+get_sampler_params <- function(fit) {
+  sp <- lapply(fit$fit@sim$samples, function(x) attr(x, "sampler_params"))
+  do.call(rbind, sp)
+}
+
 expect_convergence <- function(fit, per_dts = 0.05, treedepth = 10,
                                rhat = 1.05) {
-  np <- brms::nuts_params(fit)
-  indices <- np$Parameter == "divergent__"
-  per_divergent_transitions <- mean(np[indices, ]$Value)
-  max_treedepth <- brms::control_params(fit)$max_treedepth
+  np <- get_sampler_params(fit)
+  per_divergent_transitions <- mean(np$divergent__)
+  max_treedepth <- max(np$treedepth__)
   max_rhat <- max(brms::rhat(fit))
   testthat::expect_lt(per_divergent_transitions, per_dts)
   testthat::expect_lt(max_treedepth, treedepth)


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #134.

To do this I used `brms` functions to get the maximum treedepth and number of divergent transitions rather than `rstan`.

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [x] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
