### PR TITLE
Issue 130: Set seeds for integration tests

### DIFF
--- a/tests/testthat/test-int-latent_individual.R
+++ b/tests/testthat/test-int-latent_individual.R
@@ -18,8 +18,9 @@ extract_normal_parameters_brms <- function(prior) {
 
 test_that("epidist.epidist_latent_individual samples from the prior according to marginal Kolmogorov-Smirnov tests in the default case", { # nolint: line_length_linter.
   skip_on_cran()
+  set.seed(1)
   prior_samples <- epidist(data = prep_obs, fn = brms::brm,
-                           sample_prior = "only")
+                           sample_prior = "only", seed = 1)
   lognormal_draws <- extract_lognormal_draws(prior_samples)
   prior <- epidist_prior(data = prep_obs)
   param1 <- extract_normal_parameters_brms(prior[1, ])
@@ -35,7 +36,8 @@ test_that("epidist.epidist_latent_individual samples from the prior according to
 
 test_that("epidist.epidist_latent_individual fits and the MCMC converges in the default case", { # nolint: line_length_linter.
   skip_on_cran()
-  fit <- epidist(data = prep_obs)
+  set.seed(1)
+  fit <- epidist(data = prep_obs, seed = 1)
   expect_s3_class(fit, "brmsfit")
   expect_s3_class(fit, "epidist_fit")
   expect_convergence(fit)
@@ -43,7 +45,8 @@ test_that("epidist.epidist_latent_individual fits and the MCMC converges in the 
 
 test_that("epidist.epidist_latent_individual recovers the simulation settings for the delay distribution in the default case", { # nolint: line_length_linter.
   skip_on_cran()
-  fit <- epidist(data = prep_obs)
+  set.seed(1)
+  fit <- epidist(data = prep_obs, seed = 1)
   lognormal_draws <- extract_lognormal_draws(fit)
   # Unclear the extent to which we should expect parameter recovery here
   expect_equal(mean(lognormal_draws$meanlog), meanlog, tolerance = 0.1)
@@ -78,10 +81,11 @@ test_that("epidist.epidist_latent_individual Stan code compiles for an alternati
 
 test_that("epidist.epidist_latent_individual recovers no sex effect when none is simulated", { # nolint: line_length_linter.
   skip_on_cran()
+  set.seed(1)
   prep_obs$sex <- rbinom(n = nrow(prep_obs), size = 1, prob = 0.5)
   formula_sex <- epidist_formula(prep_obs, delay_central = ~ 1 + sex,
                                  sigma = ~ 1 + sex)
-  fit_sex <- epidist(data = prep_obs, formula = formula_sex)
+  fit_sex <- epidist(data = prep_obs, formula = formula_sex, seed = 1)
   draws <- posterior::as_draws_df(fit_sex$fit)
   expect_equal(mean(draws$b_sex), 0, tolerance = 0.2)
   expect_equal(mean(draws$b_sigma_sex), 0, tolerance = 0.2)
@@ -89,10 +93,11 @@ test_that("epidist.epidist_latent_individual recovers no sex effect when none is
 
 test_that("epidist.epidist_latent_individual fits and the MCMC converges for an alternative formula", { # nolint: line_length_linter.
   skip_on_cran()
+  set.seed(1)
   prep_obs$sex <- rbinom(n = nrow(prep_obs), size = 1, prob = 0.5)
   formula_sex <- epidist_formula(prep_obs, delay_central = ~ 1 + sex,
                                  sigma = ~ 1 + sex)
-  fit_sex <- epidist(data = prep_obs, formula = formula_sex)
+  fit_sex <- epidist(data = prep_obs, formula = formula_sex, seed = 1)
   expect_s3_class(fit_sex, "brmsfit")
   expect_s3_class(fit_sex, "epidist_fit")
   expect_convergence(fit_sex)


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #130.

I have checked that rerunning the fitting code produces the same e.g. p-values if you have both these seeds set. This should mean that the stochastic tests will now only change when directly changed (and then continue to produce the same answers).

This means that it's possible a change is made which is correct, but will repeatedly fail the CI. Making new issue for this (#161).

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
