### PR TITLE
Issue 185: Streamline and fix table in approx-inference vignette

### DIFF
--- a/vignettes/approx-inference.Rmd
+++ b/vignettes/approx-inference.Rmd
@@ -247,13 +247,9 @@ times <- list(
   "Pathfinder" = time_pathfinder
 )
 
-purrr::imap(times, function(time, name) {
-  data.frame(
-    "method" = name,
-    "time (s)" = time[["elapsed"]]
-  )
-}) |>
-  bind_rows() |>
+times |>
+  purrr::map_dbl("elapsed") |>
+  tibble::enframe(name = "method", value = "time (s)") |>
   gt::gt()
 ```
 


### PR DESCRIPTION
## Description

This fixes the appearance of the `times (s)` column in the `approx-inference` vignette (see screenshots). I also made the code a bit more compact.

Closes https://github.com/epinowcast/epidist/issues/185.

Before:
![CleanShot 2024-07-19 at 11 37 59@2x](https://github.com/user-attachments/assets/9fa18ad8-b707-4d75-ade8-b2089750ea04)

After:
![CleanShot 2024-07-19 at 11 39 17@2x](https://github.com/user-attachments/assets/b725d351-faa3-4541-8cc3-68e97588fc19)

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

