### PR TITLE
Issue #319: Fixes to Ebola vignette sex-district figures

### DIFF
--- a/vignettes/ebola.Rmd
+++ b/vignettes/ebola.Rmd
@@ -405,7 +405,7 @@ draws_sex_pmf <- obs_prep |>
 
 pmf_sex_figure <- draws_sex_pmf |>
   ggplot(aes(x = .prediction)) +
-  geom_bar(aes(y = after_stat(count / sum(count)))) +
+  geom_bar(aes(y = after_stat(count / ave(count, PANEL, FUN = sum)))) +
   labs(x = "", y = "", title = "Sex-stratified", tag = "B") +
   facet_grid(. ~ sex) +
   scale_x_continuous(limits = c(0, 30)) +
@@ -418,8 +418,16 @@ draws_sex_district_pmf <- obs_prep |>
   add_predicted_draws(fit_sex_district, ndraws = 1000)
 
 pmf_sex_district_figure <- draws_sex_district_pmf |>
+  mutate(
+    district = case_when(
+      district == "Port Loko" ~ "Port\nLoko",
+      district == "Western Rural" ~ "Western\nRural",
+      district == "Western Urban" ~ "Western\nUrban",
+      .default = district
+    )
+  ) |>
   ggplot(aes(x = .prediction)) +
-  geom_bar(aes(y = after_stat(count / sum(count)))) +
+  geom_bar(aes(y = after_stat(count / ave(count, PANEL, FUN = sum)))) +
   labs(
     x = "PMF with daily censoring and no truncation", y = "",
     title = "Sex-district-stratified", tag = "C"
@@ -431,9 +439,9 @@ pmf_sex_district_figure <- draws_sex_district_pmf |>
 
 (ref:pmf) Posterior predictions of the discrete probability mass function for each of the fitted models.
 
-```{r pmf, fig.cap="(ref:pmf)", fig.height = 12}
+```{r pmf, fig.cap="(ref:pmf)", fig.height = 16}
 pmf_base_figure / pmf_sex_figure / pmf_sex_district_figure +
-  plot_layout(heights = c(1, 1.5, 3.5))
+  plot_layout(heights = c(1, 1.5, 5.5))
 ```
 
 ### Continuous probability density function
@@ -474,6 +482,14 @@ draws_sex_district_pdf <- obs_prep |>
   add_predicted_draws(fit_sex_district, ndraws = 1000)
 
 pdf_sex_district_figure <- draws_sex_district_pdf |>
+  mutate(
+    district = case_when(
+      district == "Port Loko" ~ "Port\nLoko",
+      district == "Western Rural" ~ "Western\nRural",
+      district == "Western Urban" ~ "Western\nUrban",
+      .default = district
+    )
+  ) |>
   ggplot(aes(x = .prediction)) +
   geom_density() +
   labs(
@@ -487,9 +503,9 @@ pdf_sex_district_figure <- draws_sex_district_pdf |>
 
 (ref:pdf) Posterior predictions of the continuous probability density function for each of the fitted models.
 
-```{r pdf, fig.cap="(ref:pdf)", fig.height = 12}
+```{r pdf, fig.cap="(ref:pdf)", fig.height = 16}
 pdf_base_figure / pdf_sex_figure / pdf_sex_district_figure +
-  plot_layout(heights = c(1, 1.5, 3.5))
+  plot_layout(heights = c(1, 1.5, 5.5))
 ```
 
 # Conclusion

--- a/vignettes/ebola.Rmd
+++ b/vignettes/ebola.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Using epidist to estimate delay between symptom onset and positive test for an Ebola outbreak in Sierra Leone"
-description: "A more detailed guide to using the `epidist` R package"
+description: "A more detailed guide to using the epidist R package"
 output: 
   bookdown::html_document2:
     fig_caption: yes

--- a/vignettes/ebola.Rmd
+++ b/vignettes/ebola.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Using `epidist` to estimate stratified delays between symptom onset and positive test for the 2014-2016 Ebola outbreak in Sierra Leone"
+title: "Using epidist to estimate delay between symptom onset and positive test for an Ebola outbreak in Sierra Leone"
 description: "A more detailed guide to using the `epidist` R package"
 output: 
   bookdown::html_document2:

--- a/vignettes/ebola.Rmd
+++ b/vignettes/ebola.Rmd
@@ -431,9 +431,9 @@ pmf_sex_district_figure <- draws_sex_district_pmf |>
 
 (ref:pmf) Posterior predictions of the discrete probability mass function for each of the fitted models.
 
-```{r pmf, fig.cap="(ref:pmf)", fig.height = 9}
+```{r pmf, fig.cap="(ref:pmf)", fig.height = 12}
 pmf_base_figure / pmf_sex_figure / pmf_sex_district_figure +
-  plot_layout(heights = c(1, 1.5, 3))
+  plot_layout(heights = c(1, 1.5, 3.5))
 ```
 
 ### Continuous probability density function
@@ -487,9 +487,9 @@ pdf_sex_district_figure <- draws_sex_district_pdf |>
 
 (ref:pdf) Posterior predictions of the continuous probability density function for each of the fitted models.
 
-```{r pdf, fig.cap="(ref:pdf)", fig.height = 9}
+```{r pdf, fig.cap="(ref:pdf)", fig.height = 12}
 pdf_base_figure / pdf_sex_figure / pdf_sex_district_figure +
-  plot_layout(heights = c(1, 1.5, 3))
+  plot_layout(heights = c(1, 1.5, 3.5))
 ```
 
 # Conclusion


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #319.

As well as making the figure bigger I:

* Fixed a bug with `after_stat` and `facet_grid` giving wrong density histograms
* Recoded the districts to put a new line in two word names for the figure
* Fixed some issues with the vignette title

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
