### PR TITLE
Issue #374: Set default to `mu ~ 1` as formula

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -36,7 +36,7 @@ epidist <- function(data, formula, family, prior, backend, fn, ...) {
 #' @method epidist default
 #' @family fit
 #' @export
-epidist.default <- function(data, formula = brms::bf(mu ~ 1),
+epidist.default <- function(data, formula = mu ~ 1,
                             family = "lognormal", prior = NULL,
                             backend = "cmdstanr", fn = brms::brm, ...) {
   epidist_validate(data)

--- a/man/epidist.Rd
+++ b/man/epidist.Rd
@@ -9,10 +9,16 @@ epidist(data, formula, family, prior, backend, fn, ...)
 \arguments{
 \item{data}{A \code{data.frame} containing line list data.}
 
+<<<<<<< HEAD
 \item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
 (or one that can be coerced to those classes). A symbolic description of the
 model to be fitted. A formula must be provided for the distributional
 parameter \code{mu}, and may optionally be provided for other distributional
+=======
+\item{formula}{A formula object created using \code{brms::bf}. A formula must be
+provided for the distributional parameter \code{mu} common to all \code{brms} families.
+Optionally, formulas may also be provided for additional distributional
+>>>>>>> 802eba5d (Set mu ~ 1 as default)
 parameters.}
 
 \item{family}{A description of the response distribution and link function to
@@ -29,11 +35,19 @@ or related functions. These priors are passed to \code{\link[=epidist_prior]{epi
 fitting the Stan model. Options are \code{"rstan"} and \code{"cmdstanr"} (the default).
 This option is passed directly through to \code{fn}.}
 
+<<<<<<< HEAD
 \item{fn}{The internal function to be called. By default this is
 \code{\link[brms:brm]{brms::brm()}} which performs inference for the specified model. Other options
 are \code{\link[brms:stancode]{brms::make_stancode()}} which returns the Stan code for the specified
 model, or \code{\link[brms:standata]{brms::make_standata()}} which returns the data passed to Stan.
 These two later options may be useful for model debugging and extensions.}
+=======
+\item{fn}{The internal function to be called. By default this is \code{brms::brm},
+which performs inference for the specified model. Other options
+\code{brms::make_stancode}, which returns the Stan code for the specified model,
+and \code{brms::make_standata} which returns the data passed to Stan. These
+options may be useful for model debugging and extensions.}
+>>>>>>> 802eba5d (Set mu ~ 1 as default)
 
 \item{...}{Additional arguments passed to method.}
 }

--- a/man/epidist.Rd
+++ b/man/epidist.Rd
@@ -9,16 +9,10 @@ epidist(data, formula, family, prior, backend, fn, ...)
 \arguments{
 \item{data}{A \code{data.frame} containing line list data.}
 
-<<<<<<< HEAD
 \item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
 (or one that can be coerced to those classes). A symbolic description of the
 model to be fitted. A formula must be provided for the distributional
 parameter \code{mu}, and may optionally be provided for other distributional
-=======
-\item{formula}{A formula object created using \code{brms::bf}. A formula must be
-provided for the distributional parameter \code{mu} common to all \code{brms} families.
-Optionally, formulas may also be provided for additional distributional
->>>>>>> 802eba5d (Set mu ~ 1 as default)
 parameters.}
 
 \item{family}{A description of the response distribution and link function to
@@ -35,19 +29,11 @@ or related functions. These priors are passed to \code{\link[=epidist_prior]{epi
 fitting the Stan model. Options are \code{"rstan"} and \code{"cmdstanr"} (the default).
 This option is passed directly through to \code{fn}.}
 
-<<<<<<< HEAD
 \item{fn}{The internal function to be called. By default this is
 \code{\link[brms:brm]{brms::brm()}} which performs inference for the specified model. Other options
 are \code{\link[brms:stancode]{brms::make_stancode()}} which returns the Stan code for the specified
 model, or \code{\link[brms:standata]{brms::make_standata()}} which returns the data passed to Stan.
 These two later options may be useful for model debugging and extensions.}
-=======
-\item{fn}{The internal function to be called. By default this is \code{brms::brm},
-which performs inference for the specified model. Other options
-\code{brms::make_stancode}, which returns the Stan code for the specified model,
-and \code{brms::make_standata} which returns the data passed to Stan. These
-options may be useful for model debugging and extensions.}
->>>>>>> 802eba5d (Set mu ~ 1 as default)
 
 \item{...}{Additional arguments passed to method.}
 }

--- a/man/epidist.default.Rd
+++ b/man/epidist.default.Rd
@@ -17,16 +17,10 @@
 \arguments{
 \item{data}{A \code{data.frame} containing line list data.}
 
-<<<<<<< HEAD
 \item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
 (or one that can be coerced to those classes). A symbolic description of the
 model to be fitted. A formula must be provided for the distributional
 parameter \code{mu}, and may optionally be provided for other distributional
-=======
-\item{formula}{A formula object created using \code{brms::bf}. A formula must be
-provided for the distributional parameter \code{mu} common to all \code{brms} families.
-Optionally, formulas may also be provided for additional distributional
->>>>>>> 802eba5d (Set mu ~ 1 as default)
 parameters.}
 
 \item{family}{A description of the response distribution and link function to
@@ -43,19 +37,11 @@ or related functions. These priors are passed to \code{\link[=epidist_prior]{epi
 fitting the Stan model. Options are \code{"rstan"} and \code{"cmdstanr"} (the default).
 This option is passed directly through to \code{fn}.}
 
-<<<<<<< HEAD
 \item{fn}{The internal function to be called. By default this is
 \code{\link[brms:brm]{brms::brm()}} which performs inference for the specified model. Other options
 are \code{\link[brms:stancode]{brms::make_stancode()}} which returns the Stan code for the specified
 model, or \code{\link[brms:standata]{brms::make_standata()}} which returns the data passed to Stan.
 These two later options may be useful for model debugging and extensions.}
-=======
-\item{fn}{The internal function to be called. By default this is \code{brms::brm},
-which performs inference for the specified model. Other options
-\code{brms::make_stancode}, which returns the Stan code for the specified model,
-and \code{brms::make_standata} which returns the data passed to Stan. These
-options may be useful for model debugging and extensions.}
->>>>>>> 802eba5d (Set mu ~ 1 as default)
 
 \item{...}{Additional arguments passed to method.}
 }

--- a/man/epidist.default.Rd
+++ b/man/epidist.default.Rd
@@ -6,7 +6,7 @@
 \usage{
 \method{epidist}{default}(
   data,
-  formula = brms::bf(mu ~ 1),
+  formula = mu ~ 1,
   family = "lognormal",
   prior = NULL,
   backend = "cmdstanr",
@@ -17,10 +17,16 @@
 \arguments{
 \item{data}{A \code{data.frame} containing line list data.}
 
+<<<<<<< HEAD
 \item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
 (or one that can be coerced to those classes). A symbolic description of the
 model to be fitted. A formula must be provided for the distributional
 parameter \code{mu}, and may optionally be provided for other distributional
+=======
+\item{formula}{A formula object created using \code{brms::bf}. A formula must be
+provided for the distributional parameter \code{mu} common to all \code{brms} families.
+Optionally, formulas may also be provided for additional distributional
+>>>>>>> 802eba5d (Set mu ~ 1 as default)
 parameters.}
 
 \item{family}{A description of the response distribution and link function to
@@ -37,11 +43,19 @@ or related functions. These priors are passed to \code{\link[=epidist_prior]{epi
 fitting the Stan model. Options are \code{"rstan"} and \code{"cmdstanr"} (the default).
 This option is passed directly through to \code{fn}.}
 
+<<<<<<< HEAD
 \item{fn}{The internal function to be called. By default this is
 \code{\link[brms:brm]{brms::brm()}} which performs inference for the specified model. Other options
 are \code{\link[brms:stancode]{brms::make_stancode()}} which returns the Stan code for the specified
 model, or \code{\link[brms:standata]{brms::make_standata()}} which returns the data passed to Stan.
 These two later options may be useful for model debugging and extensions.}
+=======
+\item{fn}{The internal function to be called. By default this is \code{brms::brm},
+which performs inference for the specified model. Other options
+\code{brms::make_stancode}, which returns the Stan code for the specified model,
+and \code{brms::make_standata} which returns the data passed to Stan. These
+options may be useful for model debugging and extensions.}
+>>>>>>> 802eba5d (Set mu ~ 1 as default)
 
 \item{...}{Additional arguments passed to method.}
 }

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -22,6 +22,12 @@ test_that("epidist_formula with default settings produces a brmsformula with the
     as_string_formula(form$pforms$sigma),
     "sigma ~ 1"
   )
+  form_explicit <- epidist_formula(
+    prep_obs, family = family_lognormal, formula = brms::bf(mu ~ 1, sigma ~ 1)
+  )
+  attr(form$pforms$sigma, ".Environment") <- NULL
+  attr(form_explicit$pforms$sigma, ".Environment") <- NULL
+  expect_identical(form, form_explicit)
 })
 
 test_that("epidist_formula with custom formulas produces a brmsformula with correct custom formulas", { # nolint: line_length_linter.

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -42,6 +42,21 @@ test_that("epidist_formula with custom formulas produces a brmsformula with corr
   )
 })
 
+test_that("epidist_formula with input as a formula (not using brms::bf) produces a brmsformula", { # nolint: line_length_linter.
+  form <- epidist_formula(
+    prep_obs, family = family_lognormal, formula = mu ~ 1
+  )
+  expect_s3_class(form, "brmsformula")
+  expect_equal(
+    as_string_formula(form$formula),
+    "delay | vreal(relative_obs_time, pwindow, swindow) ~ 1"
+  )
+  expect_equal(
+    as_string_formula(form$pforms$sigma),
+    "sigma ~ 1"
+  )
+})
+
 test_that("epidist_formula with custom formulas errors for incorrect custom formulas", { # nolint: line_length_linter.
   expect_error(
     epidist_formula(

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -11,7 +11,7 @@ as_string_formula <- function(formula) {
 
 test_that("epidist_formula with default settings produces a brmsformula with the correct intercept only formula", { # nolint: line_length_linter.
   form <- epidist_formula(
-    prep_obs, family = family_lognormal, formula = brms::bf(mu ~ 1, sigma ~ 1)
+    prep_obs, family = family_lognormal, formula = mu ~ 1
   )
   expect_s3_class(form, "brmsformula")
   expect_equal(
@@ -39,21 +39,6 @@ test_that("epidist_formula with custom formulas produces a brmsformula with corr
   expect_equal(
     as_string_formula(form_sex$pforms$sigma),
     "sigma ~ 1 + sex"
-  )
-})
-
-test_that("epidist_formula with input as a formula (not using brms::bf) produces a brmsformula", { # nolint: line_length_linter.
-  form <- epidist_formula(
-    prep_obs, family = family_lognormal, formula = mu ~ 1
-  )
-  expect_s3_class(form, "brmsformula")
-  expect_equal(
-    as_string_formula(form$formula),
-    "delay | vreal(relative_obs_time, pwindow, swindow) ~ 1"
-  )
-  expect_equal(
-    as_string_formula(form$pforms$sigma),
-    "sigma ~ 1"
   )
 })
 

--- a/tests/testthat/test-int-latent_individual.R
+++ b/tests/testthat/test-int-latent_individual.R
@@ -47,7 +47,7 @@ test_that("epidist.epidist_latent_individual samples from the prior according to
   epidist_formula <- epidist_formula(
     data = prep_obs,
     family = epidist_family,
-    formula = brms::bf(mu ~ 1, sigma ~ 1)
+    formula = mu ~ 1
   )
   epidist_prior <- epidist_prior(
     data = prep_obs,
@@ -139,7 +139,7 @@ test_that("epidist.epidist_latent_individual Stan code has no syntax errors and 
   stancode_gamma <- epidist(
     data = prep_obs_gamma,
     family = stats::Gamma(link = "log"),
-    formula = brms::bf(mu ~ 1, shape ~ 1),
+    formula = mu ~ 1,
     output_dir = fs::dir_create(tempfile()),
     fn = brms::make_stancode
   )
@@ -157,7 +157,7 @@ test_that("epidist.epidist_latent_individual fits and the MCMC converges in the 
   fit_gamma <- epidist(
     data = prep_obs_gamma,
     family = stats::Gamma(link = "log"),
-    formula = brms::bf(mu ~ 1, shape ~ 1),
+    formula = mu ~ 1,
     seed = 1,
     silent = 2,
     output_dir = fs::dir_create(tempfile())
@@ -174,7 +174,7 @@ test_that("epidist.epidist_latent_individual recovers the simulation settings fo
   fit_gamma <- epidist(
     data = prep_obs_gamma,
     family = stats::Gamma(link = "log"),
-    formula = brms::bf(mu ~ 1, shape ~ 1),
+    formula = mu ~ 1,
     seed = 1,
     silent = 2,
     output_dir = fs::dir_create(tempfile())

--- a/vignettes/ebola.Rmd
+++ b/vignettes/ebola.Rmd
@@ -213,7 +213,8 @@ Now we are ready to fit the latent individual model.
 We start by fitting a single lognormal distribution to the data. 
 This model assumes that a single distribution describes all delays in the data, regardless of the case's location, sex, or any other covariates.
 To do this, we set `formula = bf(mu ~ 1, sigma ~ 1)` to place an model with only and intercept parameter (i.e. `~ 1` in R formula syntax) on the `mu` and `sigma` parameters of the lognormal distribution.
-This distribution is specified using `family = lognormal()`.
+Note that this is equivalent to specifying `formula = mu ~ 1`, the default option.
+The likelihood distribution is specified using `family = lognormal()`.
 
 ```{r}
 fit <- epidist(

--- a/vignettes/ebola.Rmd
+++ b/vignettes/ebola.Rmd
@@ -212,9 +212,8 @@ Now we are ready to fit the latent individual model.
 
 We start by fitting a single lognormal distribution to the data. 
 This model assumes that a single distribution describes all delays in the data, regardless of the case's location, sex, or any other covariates.
-To do this, we set `formula = bf(mu ~ 1, sigma ~ 1)` to place an model with only and intercept parameter (i.e. `~ 1` in R formula syntax) on the `mu` and `sigma` parameters of the lognormal distribution.
-Note that this is equivalent to specifying `formula = mu ~ 1`, the default option.
-The likelihood distribution is specified using `family = lognormal()`.
+To do this, we set `formula = bf(mu ~ 1, sigma ~ 1)` to place an model with only and intercept parameter (i.e. `~ 1` in R formula syntax) on the `mu` and `sigma` parameters of the lognormal distribution specified using `family = lognormal()`.
+Note that this is equivalent to specifying `formula = mu ~ 1`, the default option in `epidist()`, because we model all distributional parameters of the likelihood using a constant by default.
 
 ```{r}
 fit <- epidist(

--- a/vignettes/ebola.Rmd
+++ b/vignettes/ebola.Rmd
@@ -212,13 +212,14 @@ Now we are ready to fit the latent individual model.
 
 We start by fitting a single lognormal distribution to the data. 
 This model assumes that a single distribution describes all delays in the data, regardless of the case's location, sex, or any other covariates.
-To do this, we set `formula = bf(mu ~ 1, sigma ~ 1)` to place an model with only and intercept parameter (i.e. `~ 1` in R formula syntax) on the `mu` and `sigma` parameters of the lognormal distribution specified using `family = lognormal()`.
-Note that this is equivalent to specifying `formula = mu ~ 1`, the default option in `epidist()`, because we model all distributional parameters of the likelihood using a constant by default.
+To do this, we set `formula = mu ~ 1` to place an model with only an intercept parameter (i.e. `~ 1` in R formula syntax) on the `mu` parameter of the lognormal distribution specified using `family = lognormal()`.
+(Note that the lognormal distribution has two distributional parameters `mu` and `sigma`.
+As a model is not explicitly placed on `sigma`, a constant model `sigma ~ 1` is assumed.) 
 
 ```{r}
 fit <- epidist(
   data = obs_prep,
-  formula = bf(mu ~ 1, sigma ~ 1),
+  formula = mu ~ 1,
   family = lognormal(),
   algorithm = "sampling",
   refresh = 0,

--- a/vignettes/faq.Rmd
+++ b/vignettes/faq.Rmd
@@ -50,7 +50,7 @@ obs_cens_trunc_samp <- simulate_gillespie(seed = 101) |>
 data <- as_latent_individual(obs_cens_trunc_samp)
 fit <- epidist(
   data,
-  formula = bf(mu ~ 1, sigma ~ 1),
+  formula = mu ~ 1,
   seed = 1
 )
 ```
@@ -108,7 +108,7 @@ family <- "lognormal"
 
 epidist_family <- epidist_family(data, family)
 epidist_formula <- epidist_formula(
-  data, family = epidist_family, formula = bf(mu ~ 1, sigma ~ 1)
+  data, family = epidist_family, formula = mu ~ 1
 )
 
 # NULL here means no replacing priors from the user!
@@ -130,7 +130,7 @@ Here are the distributions on the delay distribution mean and standard deviation
 set.seed(1)
 fit_ppc <- epidist(
   data = data,
-  formula = bf(mu ~ 1, sigma ~ 1),
+  formula = mu ~ 1,
   family = "lognormal",
   sample_prior = "only",
   seed = 1


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #374.

I think we already had things set up to work fine with `formula = mu ~ 1` because `epidist_formula` is calling:

```r
formula <- brms:::validate_formula(formula, data = data, family = family)
```

So it already is going to convert from `mu ~ 1` to ` brms::bf`.

I added one unit test to check this.

Edit: this unit test was later removed in favour of using `mu ~ 1` as the default.

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [x] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required.
- [x] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [x] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
