### PR TITLE
Issue #298: `epidist_prior` accepting output of `epidist_family` and improved argument documentation

### DIFF
--- a/R/family.R
+++ b/R/family.R
@@ -5,10 +5,7 @@
 #' that as a user you will need this function, but we export it nonetheless to
 #' be transparent about what happens inside of a call to [epidist()].
 #'
-#' @param data A `data.frame` containing line list data
-#' @param family Output of a call to `brms::brmsfamily()`
-#' @param ... ...
-#'
+#' @inheritParams epidist
 #' @family family
 #' @export
 epidist_family <- function(data, family = "lognormal", ...) {
@@ -24,10 +21,9 @@ epidist_family <- function(data, family = "lognormal", ...) {
 
 #' The model-specific parts of an `epidist_family()` call
 #'
-#' @inheritParams epidist_family
+#' @inheritParams epidist
 #' @param family Output of a call to `brms::brmsfamily()` with additional
 #' information as provided by `.add_dpar_info()`
-#' @param ... Additional arguments passed to method.
 #' @rdname epidist_family_model
 #' @family family
 #' @export
@@ -38,7 +34,6 @@ epidist_family_model <- function(data, family, ...) {
 #' Default method for defining a model specific family
 #'
 #' @inheritParams epidist_family_model
-#' @param ... Additional arguments passed to method.
 #' @family family
 #' @export
 epidist_family_model.default <- function(data, family, ...) {
@@ -48,7 +43,6 @@ epidist_family_model.default <- function(data, family, ...) {
 #' Reparameterise an `epidist` family to align `brms` and Stan
 #'
 #' @inheritParams epidist_family
-#' @param ... Additional arguments passed to method.
 #' @rdname epidist_family_reparam
 #' @family family
 #' @export
@@ -58,8 +52,7 @@ epidist_family_reparam <- function(family, ...) {
 
 #' Default method for families which do not require a reparameterisation
 #'
-#' @inheritParams epidist_family_reparam
-#' @param ... Additional arguments passed to method.
+#' @inheritParams epidist_family
 #' @family family
 #' @export
 epidist_family_reparam.default <- function(family, ...) {
@@ -69,8 +62,7 @@ epidist_family_reparam.default <- function(family, ...) {
 
 #' Reparameterisation for the gamma family
 #'
-#' @inheritParams epidist_family_reparam
-#' @param ... Additional arguments passed to method.
+#' @inheritParams epidist_family
 #' @family family
 #' @export
 epidist_family_reparam.gamma <- function(family, ...) {

--- a/R/fit.R
+++ b/R/fit.R
@@ -1,9 +1,10 @@
 #' Fit epidemiological delay distributions using a `brms` interface
 #'
-#' @inheritParams epidist_validate
-#' @param formula A formula object created using `brms::bf`. A formula must be
-#' provided for the distributional parameter `mu` common to all `brms` families.
-#' Optionally, formulas may also be provided for additional distributional
+#' @param data A `data.frame` containing line list data.
+#' @param formula An object of class [stats::formula] or [brms::brmsformula]
+#' (or one that can be coerced to those classes). A symbolic description of the
+#' model to be fitted. A formula must be provided for the distributional
+#' parameter `mu`, and may optionally be provided for other distributional
 #' parameters.
 #' @param family A description of the response distribution and link function to
 #' be used in the model. Every family function has a link argument allowing
@@ -12,17 +13,16 @@
 #' see [brmsfamily()].
 #' @param prior One or more `brmsprior` objects created by [brms::set_prior()]
 #' or related functions. These priors are passed to [epidist_prior()] in the
-#' `prior` argument. We recommend caution and the use of prior predictive checks
-#' for specifying prior distributions.
+#' `prior` argument.
 #' @param backend Character string naming the package to use as the backend for
 #' fitting the Stan model. Options are `"rstan"` and `"cmdstanr"` (the default).
 #' This option is passed directly through to `fn`.
-#' @param fn The internal function to be called. By default this is `brms::brm`,
-#' which performs inference for the specified model. Other options
-#' `brms::make_stancode`, which returns the Stan code for the specified model,
-#' and `brms::make_standata` which returns the data passed to Stan. These
-#' options may be useful for model debugging and extensions.
-#' @param ... Additional arguments for method.
+#' @param fn The internal function to be called. By default this is
+#' [brms::brm()] which performs inference for the specified model. Other options
+#' are [brms::make_stancode()] which returns the Stan code for the specified
+#' model, or [brms::make_standata()] which returns the data passed to Stan.
+#' These two later options may be useful for model debugging and extensions.
+#' @param ... Additional arguments passed to method.
 #' @family fit
 #' @export
 epidist <- function(data, formula, family, prior, backend, fn, ...) {

--- a/R/fit.R
+++ b/R/fit.R
@@ -45,7 +45,7 @@ epidist.default <- function(data, formula = brms::bf(mu ~ 1),
     data = data, family = epidist_family, formula = formula
   )
   epidist_prior <- epidist_prior(
-    data = data, family = family, formula = epidist_formula, prior
+    data = data, family = epidist_family, formula = epidist_formula, prior
   )
   epidist_stancode <- epidist_stancode(
     data = data, family = epidist_family, formula = epidist_formula

--- a/R/formula.R
+++ b/R/formula.R
@@ -5,11 +5,9 @@
 #' export it nonetheless to be transparent about what exactly is happening
 #' inside of a call to [epidist()].
 #'
-#' @param data A `data.frame` containing line list data
-#' @param family Output of a call to `brms::brmsfamily()`
-#' @param formula As produced by [brms::brmsformula()]
-#' @param ... ...
-#'
+#' @inheritParams epidist
+#' @param family A description of the response distribution and link function to
+#' be used in the model created using [epidist_family()].
 #' @family formula
 #' @export
 epidist_formula <- function(data, family, formula, ...) {
@@ -25,8 +23,7 @@ epidist_formula <- function(data, family, formula, ...) {
 
 #' The model-specific parts of an `epidist_formula()` call
 #'
-#' @inheritParams epidist_formula
-#' @param ... Additional arguments passed to method.
+#' @inheritParams epidist
 #' @rdname epidist_family_model
 #' @family formula
 #' @export
@@ -36,8 +33,7 @@ epidist_formula_model <- function(data, formula, ...) {
 
 #' Default method for defining a model specific formula
 #'
-#' @inheritParams epidist_formula
-#' @param ... Additional arguments passed to method.
+#' @inheritParams epidist
 #' @family formula
 #' @export
 epidist_formula_model.default <- function(data, formula, ...) {

--- a/R/prior.R
+++ b/R/prior.R
@@ -26,6 +26,9 @@ epidist_prior <- function(data, family, formula, prior) {
   default <- brms::default_prior(formula, data = data)
   model <- epidist_model_prior(data, formula)
   family <-  epidist_family_prior(family, formula)
+  family$source <- "family"
+  family[is.na(family)] <- "" # brms likes empty over NA
+  family[family == "NA"] <- NA # To keep particular NA
   internal_prior <- Reduce(.replace_prior, list(default, model, family))
   prior <- .replace_prior(internal_prior, prior, warn = TRUE)
   return(prior)
@@ -96,8 +99,5 @@ epidist_family_prior.lognormal <- function(family, formula, ...) {
   prior <- prior("normal(1, 1)", class = "Intercept")
   sigma_prior <- prior("normal(-0.7, 0.4)", class = "Intercept", dpar = "sigma")
   prior <- prior + sigma_prior
-  prior$source <- "family"
-  prior[is.na(prior)] <- "" # This is because brms likes empty over NA
-  prior[prior == "NA"] <- NA # To keep particular NA
   return(prior)
 }

--- a/R/prior.R
+++ b/R/prior.R
@@ -13,7 +13,7 @@
 #' distributions for parameters which are not in the model.
 #'
 #' @param data A `data.frame` containing line list data
-#' @param family Output of a call to `brms::brmsfamily()`
+#' @param family Output of a call to `epidist_family()`
 #' @param formula A formula object created using `brms::bf()`
 #' @param prior User provided prior distribution created using `brms::prior()`
 #' @rdname epidist_prior
@@ -21,8 +21,6 @@
 #' @export
 epidist_prior <- function(data, family, formula, prior) {
   epidist_validate(data)
-  family <- brms:::validate_family(family)
-  class(family) <- c(class(family), family$family)
   default <- brms::default_prior(formula, data = data)
   model <- epidist_model_prior(data, formula)
   family <-  epidist_family_prior(family, formula)

--- a/R/prior.R
+++ b/R/prior.R
@@ -12,10 +12,11 @@
 #' a warning will be shown. To prevent this warning, do not pass prior
 #' distributions for parameters which are not in the model.
 #'
-#' @param data A `data.frame` containing line list data
-#' @param family Output of a call to `epidist_family()`
-#' @param formula A formula object created using `brms::bf()`
-#' @param prior User provided prior distribution created using `brms::prior()`
+#' @inheritParams epidist
+#' @param family A description of the response distribution and link function to
+#' be used in the model created using [epidist_family()].
+#' @param formula A symbolic description of the model to be fitted created using
+#' [epidist_formula()].
 #' @rdname epidist_prior
 #' @family prior
 #' @export
@@ -37,8 +38,7 @@ epidist_prior <- function(data, family, formula, prior) {
 #' This function contains `brms` prior distributions which are specific to
 #' particular `epidist` models e.g. the `latent_lognormal` model.
 #'
-#' @inheritParams epidist_prior
-#' @param ... ...
+#' @inheritParams epidist
 #' @rdname epidist_model_prior
 #' @family prior
 #' @export
@@ -50,8 +50,7 @@ epidist_model_prior <- function(data, ...) {
 #'
 #' By default, we do not return any model specific prior distributions.
 #'
-#' @inheritParams epidist_prior
-#' @param ... ...
+#' @inheritParams epidist
 #' @family prior
 #' @export
 epidist_model_prior.default <- function(data, formula, ...) {
@@ -63,8 +62,7 @@ epidist_model_prior.default <- function(data, formula, ...) {
 #' This function contains `brms` prior distributions which are specific to
 #' particular likelihood families e.g. [brms::lognormal()].
 #'
-#' @inheritParams epidist_prior
-#' @param ... ...
+#' @inheritParams epidist
 #' @rdname epidist_family_prior
 #' @family prior
 #' @export
@@ -76,8 +74,7 @@ epidist_family_prior <- function(family, ...) {
 #'
 #' By default, we do not return any family specific prior distributions.
 #'
-#' @inheritParams epidist_prior
-#' @param ... ...
+#' @inheritParams epidist
 #' @family prior
 #' @export
 epidist_family_prior.default <- function(family, formula, ...) {
@@ -88,8 +85,7 @@ epidist_family_prior.default <- function(family, formula, ...) {
 #'
 #' We suggest priors to overwrite the `brms` defaults for the lognormal family.
 #'
-#' @inheritParams epidist_prior
-#' @param ... ...
+#' @inheritParams epidist
 #' @method epidist_family_prior lognormal
 #' @family prior
 #' @export

--- a/R/prior.R
+++ b/R/prior.R
@@ -25,9 +25,11 @@ epidist_prior <- function(data, family, formula, prior) {
   default <- brms::default_prior(formula, data = data)
   model <- epidist_model_prior(data, formula)
   family <-  epidist_family_prior(family, formula)
-  family$source <- "family"
-  family[is.na(family)] <- "" # brms likes empty over NA
-  family[family == "NA"] <- NA # To keep particular NA
+  if (!is.null(family)) {
+    family$source <- "family"
+    family[is.na(family)] <- "" # brms likes empty over NA
+    family[family == "NA"] <- NA # To keep particular NA
+  }
   internal_prior <- Reduce(.replace_prior, list(default, model, family))
   prior <- .replace_prior(internal_prior, prior, warn = TRUE)
   return(prior)

--- a/R/stancode.R
+++ b/R/stancode.R
@@ -5,8 +5,7 @@
 #' as a user you will need this function, but we export it nonetheless to be
 #' transparent about what exactly is happening inside of a call to [epidist()].
 #'
-#' @inheritParams epidist_validate
-#' @param ... Additional arguments passed to method.
+#' @inheritParams epidist
 #' @rdname epidist_stancode
 #' @family stan
 #' @export
@@ -16,8 +15,7 @@ epidist_stancode <- function(data, ...) {
 
 #' Default method for defining model specific Stan code
 #'
-#' @inheritParams epidist_stancode
-#' @param ... Additional arguments passed to method.
+#' @inheritParams epidist
 #' @family stan
 #' @export
 epidist_stancode.default <- function(data, ...) {

--- a/R/validate.R
+++ b/R/validate.R
@@ -4,8 +4,7 @@
 #' particular `epidist` model. This may include checking the class of `data`,
 #' and that it contains suitable columns.
 #'
-#' @param data A `data.frame` containing line list data.
-#' @param ... Additional arguments passed to method.
+#' @inheritParams epidist
 #' @family validate
 #' @export
 epidist_validate <- function(data, ...) {
@@ -14,8 +13,7 @@ epidist_validate <- function(data, ...) {
 
 #' Default method for data validation
 #'
-#' @inheritParams epidist_validate
-#' @param ... Additional arguments passed to method.
+#' @inheritParams epidist
 #' @family validate
 #' @export
 epidist_validate.default <- function(data, ...) {

--- a/man/dot-add_dpar_info.Rd
+++ b/man/dot-add_dpar_info.Rd
@@ -7,7 +7,11 @@
 .add_dpar_info(family)
 }
 \arguments{
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model. Every family function has a link argument allowing
+users to specify the link function to be applied on the response variable.
+If not specified, default links are used. For details of supported families
+see \code{\link[=brmsfamily]{brmsfamily()}}.}
 }
 \description{
 Includes additional information (link functions and parameter bound) about

--- a/man/epidist.Rd
+++ b/man/epidist.Rd
@@ -9,9 +9,10 @@ epidist(data, formula, family, prior, backend, fn, ...)
 \arguments{
 \item{data}{A \code{data.frame} containing line list data.}
 
-\item{formula}{A formula object created using \code{\link[brms:brmsformula]{brms::bf()}}. A formula must be
-provided for the distributional parameter \code{mu} common to all \code{brms} families.
-Optionally, formulas may also be provided for additional distributional
+\item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
+(or one that can be coerced to those classes). A symbolic description of the
+model to be fitted. A formula must be provided for the distributional
+parameter \code{mu}, and may optionally be provided for other distributional
 parameters.}
 
 \item{family}{A description of the response distribution and link function to
@@ -22,8 +23,7 @@ see \code{\link[=brmsfamily]{brmsfamily()}}.}
 
 \item{prior}{One or more \code{brmsprior} objects created by \code{\link[brms:set_prior]{brms::set_prior()}}
 or related functions. These priors are passed to \code{\link[=epidist_prior]{epidist_prior()}} in the
-\code{prior} argument. We recommend caution and the use of prior predictive checks
-for specifying prior distributions.}
+\code{prior} argument.}
 
 \item{backend}{Character string naming the package to use as the backend for
 fitting the Stan model. Options are \code{"rstan"} and \code{"cmdstanr"} (the default).
@@ -31,11 +31,11 @@ This option is passed directly through to \code{fn}.}
 
 \item{fn}{The internal function to be called. By default this is
 \code{\link[brms:brm]{brms::brm()}} which performs inference for the specified model. Other options
-\code{\link[brms:stancode]{brms::make_stancode()}}, which returns the Stan code for the specified model,
-and \code{\link[brms:standata]{brms::make_standata()}} which returns the data passed to Stan. These
-options may be useful for model debugging and extensions.}
+are \code{\link[brms:stancode]{brms::make_stancode()}} which returns the Stan code for the specified
+model, or \code{\link[brms:standata]{brms::make_standata()}} which returns the data passed to Stan.
+These two later options may be useful for model debugging and extensions.}
 
-\item{...}{Additional arguments for method.}
+\item{...}{Additional arguments passed to method.}
 }
 \description{
 Fit epidemiological delay distributions using a \code{brms} interface

--- a/man/epidist.default.Rd
+++ b/man/epidist.default.Rd
@@ -17,9 +17,10 @@
 \arguments{
 \item{data}{A \code{data.frame} containing line list data.}
 
-\item{formula}{A formula object created using \code{\link[brms:brmsformula]{brms::bf()}}. A formula must be
-provided for the distributional parameter \code{mu} common to all \code{brms} families.
-Optionally, formulas may also be provided for additional distributional
+\item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
+(or one that can be coerced to those classes). A symbolic description of the
+model to be fitted. A formula must be provided for the distributional
+parameter \code{mu}, and may optionally be provided for other distributional
 parameters.}
 
 \item{family}{A description of the response distribution and link function to
@@ -30,8 +31,7 @@ see \code{\link[=brmsfamily]{brmsfamily()}}.}
 
 \item{prior}{One or more \code{brmsprior} objects created by \code{\link[brms:set_prior]{brms::set_prior()}}
 or related functions. These priors are passed to \code{\link[=epidist_prior]{epidist_prior()}} in the
-\code{prior} argument. We recommend caution and the use of prior predictive checks
-for specifying prior distributions.}
+\code{prior} argument.}
 
 \item{backend}{Character string naming the package to use as the backend for
 fitting the Stan model. Options are \code{"rstan"} and \code{"cmdstanr"} (the default).
@@ -39,11 +39,11 @@ This option is passed directly through to \code{fn}.}
 
 \item{fn}{The internal function to be called. By default this is
 \code{\link[brms:brm]{brms::brm()}} which performs inference for the specified model. Other options
-\code{\link[brms:stancode]{brms::make_stancode()}}, which returns the Stan code for the specified model,
-and \code{\link[brms:standata]{brms::make_standata()}} which returns the data passed to Stan. These
-options may be useful for model debugging and extensions.}
+are \code{\link[brms:stancode]{brms::make_stancode()}} which returns the Stan code for the specified
+model, or \code{\link[brms:standata]{brms::make_standata()}} which returns the data passed to Stan.
+These two later options may be useful for model debugging and extensions.}
 
-\item{...}{Additional arguments for method.}
+\item{...}{Additional arguments passed to method.}
 }
 \description{
 Default method used for interface using \code{brms}

--- a/man/epidist_family.Rd
+++ b/man/epidist_family.Rd
@@ -7,11 +7,15 @@
 epidist_family(data, family = "lognormal", ...)
 }
 \arguments{
-\item{data}{A \code{data.frame} containing line list data}
+\item{data}{A \code{data.frame} containing line list data.}
 
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model. Every family function has a link argument allowing
+users to specify the link function to be applied on the response variable.
+If not specified, default links are used. For details of supported families
+see \code{\link[=brmsfamily]{brmsfamily()}}.}
 
-\item{...}{...}
+\item{...}{Additional arguments passed to method.}
 }
 \description{
 This function is used within \code{\link[=epidist]{epidist()}} to create a model specific custom

--- a/man/epidist_family_model.Rd
+++ b/man/epidist_family_model.Rd
@@ -10,14 +10,18 @@ epidist_family_model(data, family, ...)
 epidist_formula_model(data, formula, ...)
 }
 \arguments{
-\item{data}{A \code{data.frame} containing line list data}
+\item{data}{A \code{data.frame} containing line list data.}
 
 \item{family}{Output of a call to \code{brms::brmsfamily()} with additional
 information as provided by \code{.add_dpar_info()}}
 
 \item{...}{Additional arguments passed to method.}
 
-\item{formula}{As produced by \code{\link[brms:brmsformula]{brms::brmsformula()}}}
+\item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
+(or one that can be coerced to those classes). A symbolic description of the
+model to be fitted. A formula must be provided for the distributional
+parameter \code{mu}, and may optionally be provided for other distributional
+parameters.}
 }
 \description{
 The model-specific parts of an \code{epidist_family()} call

--- a/man/epidist_family_model.default.Rd
+++ b/man/epidist_family_model.default.Rd
@@ -7,7 +7,7 @@
 \method{epidist_family_model}{default}(data, family, ...)
 }
 \arguments{
-\item{data}{A \code{data.frame} containing line list data}
+\item{data}{A \code{data.frame} containing line list data.}
 
 \item{family}{Output of a call to \code{brms::brmsfamily()} with additional
 information as provided by \code{.add_dpar_info()}}

--- a/man/epidist_family_model.epidist_latent_individual.Rd
+++ b/man/epidist_family_model.epidist_latent_individual.Rd
@@ -7,7 +7,7 @@
 \method{epidist_family_model}{epidist_latent_individual}(data, family, ...)
 }
 \arguments{
-\item{data}{A \code{data.frame} containing line list data}
+\item{data}{A \code{data.frame} containing line list data.}
 
 \item{family}{Output of a call to \code{brms::brmsfamily()} with additional
 information as provided by \code{.add_dpar_info()}}

--- a/man/epidist_family_prior.Rd
+++ b/man/epidist_family_prior.Rd
@@ -7,9 +7,13 @@
 epidist_family_prior(family, ...)
 }
 \arguments{
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model. Every family function has a link argument allowing
+users to specify the link function to be applied on the response variable.
+If not specified, default links are used. For details of supported families
+see \code{\link[=brmsfamily]{brmsfamily()}}.}
 
-\item{...}{...}
+\item{...}{Additional arguments passed to method.}
 }
 \description{
 This function contains \code{brms} prior distributions which are specific to

--- a/man/epidist_family_prior.default.Rd
+++ b/man/epidist_family_prior.default.Rd
@@ -7,11 +7,19 @@
 \method{epidist_family_prior}{default}(family, formula, ...)
 }
 \arguments{
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model. Every family function has a link argument allowing
+users to specify the link function to be applied on the response variable.
+If not specified, default links are used. For details of supported families
+see \code{\link[=brmsfamily]{brmsfamily()}}.}
 
-\item{formula}{A formula object created using \code{brms::bf()}}
+\item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
+(or one that can be coerced to those classes). A symbolic description of the
+model to be fitted. A formula must be provided for the distributional
+parameter \code{mu}, and may optionally be provided for other distributional
+parameters.}
 
-\item{...}{...}
+\item{...}{Additional arguments passed to method.}
 }
 \description{
 By default, we do not return any family specific prior distributions.

--- a/man/epidist_family_prior.lognormal.Rd
+++ b/man/epidist_family_prior.lognormal.Rd
@@ -7,11 +7,19 @@
 \method{epidist_family_prior}{lognormal}(family, formula, ...)
 }
 \arguments{
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model. Every family function has a link argument allowing
+users to specify the link function to be applied on the response variable.
+If not specified, default links are used. For details of supported families
+see \code{\link[=brmsfamily]{brmsfamily()}}.}
 
-\item{formula}{A formula object created using \code{brms::bf()}}
+\item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
+(or one that can be coerced to those classes). A symbolic description of the
+model to be fitted. A formula must be provided for the distributional
+parameter \code{mu}, and may optionally be provided for other distributional
+parameters.}
 
-\item{...}{...}
+\item{...}{Additional arguments passed to method.}
 }
 \description{
 We suggest priors to overwrite the \code{brms} defaults for the lognormal family.

--- a/man/epidist_family_reparam.Rd
+++ b/man/epidist_family_reparam.Rd
@@ -7,7 +7,11 @@
 epidist_family_reparam(family, ...)
 }
 \arguments{
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model. Every family function has a link argument allowing
+users to specify the link function to be applied on the response variable.
+If not specified, default links are used. For details of supported families
+see \code{\link[=brmsfamily]{brmsfamily()}}.}
 
 \item{...}{Additional arguments passed to method.}
 }

--- a/man/epidist_family_reparam.default.Rd
+++ b/man/epidist_family_reparam.default.Rd
@@ -7,7 +7,11 @@
 \method{epidist_family_reparam}{default}(family, ...)
 }
 \arguments{
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model. Every family function has a link argument allowing
+users to specify the link function to be applied on the response variable.
+If not specified, default links are used. For details of supported families
+see \code{\link[=brmsfamily]{brmsfamily()}}.}
 
 \item{...}{Additional arguments passed to method.}
 }

--- a/man/epidist_family_reparam.gamma.Rd
+++ b/man/epidist_family_reparam.gamma.Rd
@@ -7,7 +7,11 @@
 \method{epidist_family_reparam}{gamma}(family, ...)
 }
 \arguments{
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model. Every family function has a link argument allowing
+users to specify the link function to be applied on the response variable.
+If not specified, default links are used. For details of supported families
+see \code{\link[=brmsfamily]{brmsfamily()}}.}
 
 \item{...}{Additional arguments passed to method.}
 }

--- a/man/epidist_formula.Rd
+++ b/man/epidist_formula.Rd
@@ -7,13 +7,18 @@
 epidist_formula(data, family, formula, ...)
 }
 \arguments{
-\item{data}{A \code{data.frame} containing line list data}
+\item{data}{A \code{data.frame} containing line list data.}
 
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model created using \code{\link[=epidist_family]{epidist_family()}}.}
 
-\item{formula}{As produced by \code{\link[brms:brmsformula]{brms::brmsformula()}}}
+\item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
+(or one that can be coerced to those classes). A symbolic description of the
+model to be fitted. A formula must be provided for the distributional
+parameter \code{mu}, and may optionally be provided for other distributional
+parameters.}
 
-\item{...}{...}
+\item{...}{Additional arguments passed to method.}
 }
 \description{
 This function is used within \code{\link[=epidist]{epidist()}} to create the formula object passed

--- a/man/epidist_formula_model.default.Rd
+++ b/man/epidist_formula_model.default.Rd
@@ -7,9 +7,13 @@
 \method{epidist_formula_model}{default}(data, formula, ...)
 }
 \arguments{
-\item{data}{A \code{data.frame} containing line list data}
+\item{data}{A \code{data.frame} containing line list data.}
 
-\item{formula}{As produced by \code{\link[brms:brmsformula]{brms::brmsformula()}}}
+\item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
+(or one that can be coerced to those classes). A symbolic description of the
+model to be fitted. A formula must be provided for the distributional
+parameter \code{mu}, and may optionally be provided for other distributional
+parameters.}
 
 \item{...}{Additional arguments passed to method.}
 }

--- a/man/epidist_model_prior.Rd
+++ b/man/epidist_model_prior.Rd
@@ -7,9 +7,9 @@
 epidist_model_prior(data, ...)
 }
 \arguments{
-\item{data}{A \code{data.frame} containing line list data}
+\item{data}{A \code{data.frame} containing line list data.}
 
-\item{...}{...}
+\item{...}{Additional arguments passed to method.}
 }
 \description{
 This function contains \code{brms} prior distributions which are specific to

--- a/man/epidist_model_prior.default.Rd
+++ b/man/epidist_model_prior.default.Rd
@@ -7,11 +7,15 @@
 \method{epidist_model_prior}{default}(data, formula, ...)
 }
 \arguments{
-\item{data}{A \code{data.frame} containing line list data}
+\item{data}{A \code{data.frame} containing line list data.}
 
-\item{formula}{A formula object created using \code{brms::bf()}}
+\item{formula}{An object of class \link[stats:formula]{stats::formula} or \link[brms:brmsformula]{brms::brmsformula}
+(or one that can be coerced to those classes). A symbolic description of the
+model to be fitted. A formula must be provided for the distributional
+parameter \code{mu}, and may optionally be provided for other distributional
+parameters.}
 
-\item{...}{...}
+\item{...}{Additional arguments passed to method.}
 }
 \description{
 By default, we do not return any model specific prior distributions.

--- a/man/epidist_prior.Rd
+++ b/man/epidist_prior.Rd
@@ -8,13 +8,17 @@ family specific priors, and user provided priors}
 epidist_prior(data, family, formula, prior)
 }
 \arguments{
-\item{data}{A \code{data.frame} containing line list data}
+\item{data}{A \code{data.frame} containing line list data.}
 
-\item{family}{Output of a call to \code{brms::brmsfamily()}}
+\item{family}{A description of the response distribution and link function to
+be used in the model created using \code{\link[=epidist_family]{epidist_family()}}.}
 
-\item{formula}{A formula object created using \code{brms::bf()}}
+\item{formula}{A symbolic description of the model to be fitted created using
+\code{\link[=epidist_formula]{epidist_formula()}}.}
 
-\item{prior}{User provided prior distribution created using \code{brms::prior()}}
+\item{prior}{One or more \code{brmsprior} objects created by \code{\link[brms:set_prior]{brms::set_prior()}}
+or related functions. These priors are passed to \code{\link[=epidist_prior]{epidist_prior()}} in the
+\code{prior} argument.}
 }
 \description{
 This function obtains the \code{brms} default prior distributions for a particular

--- a/tests/testthat/test-int-latent_individual.R
+++ b/tests/testthat/test-int-latent_individual.R
@@ -51,7 +51,7 @@ test_that("epidist.epidist_latent_individual samples from the prior according to
   )
   epidist_prior <- epidist_prior(
     data = prep_obs,
-    family = family,
+    family = epidist_family,
     formula = epidist_formula,
     prior = NULL
   )

--- a/tests/testthat/test-prior.R
+++ b/tests/testthat/test-prior.R
@@ -2,10 +2,11 @@ test_that("epidist_prior with default settings produces an object of the right c
   data <- as_latent_individual(sim_obs)
   family <- brms::lognormal()
   formula <- brms::bf(mu ~ 1, sigma ~ 1)
+  epidist_family <- epidist_family(data, family)
   epidist_formula <- epidist_formula(
-    data = data, family = epidist_family(data, family), formula = formula
+    data = data, family = epidist_family, formula = formula
   )
-  prior <- epidist_prior(data, family, formula = epidist_formula, prior = NULL)
+  prior <- epidist_prior(data, epidist_family, epidist_formula, prior = NULL)
   expect_s3_class(prior, "brmsprior")
   expect_s3_class(prior, "data.frame")
 })


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #298.

Changes made:

* Move lines that are called in `epidist_family_prior.class` into `epidist_family` if they are independent of `class`
* Remove adding class to object in `epidist_family` because `epidist_family` already does it
* Set `epidist_prior` to take `epidist_family` as input rather than `family`
* Alter documentation to be clearer about `family` and `epidist_family`, `formula` and `epidist_formula`, ...
* Fixes to tests...

Warrants future issues:

* I think after we get the processing in we need to go through e.g. `latent_individual.R` and fix the documentation. Right now it's a bit of a mess

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
