### PR TITLE
Issue #194: Update tests to expect particular warnings

### DIFF
--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,0 +1,56 @@
+# .replace_prior errors when passed a new prior without a match in old_prior [plain]
+
+    Code
+      .replace_prior(old_prior, new_prior, warn = TRUE)
+    Condition
+      Warning:
+      ! One or more priors have no match in existing parameters:
+      Intercept_shape ~ normal(0, 5)
+      i To remove this warning consider changing prior specification.
+    Output
+              prior     class coef group resp  dpar nlpar   lb   ub source
+       normal(0, 5) Intercept                             <NA> <NA>   user
+       normal(0, 5) Intercept                 sigma       <NA> <NA>   user
+
+# .replace_prior errors when passed a new prior without a match in old_prior [ansi]
+
+    Code
+      .replace_prior(old_prior, new_prior, warn = TRUE)
+    Condition
+      [1m[33mWarning[39m:[22m
+      [1m[22m[33m![39m One or more priors have no match in existing parameters:
+      Intercept_shape ~ normal(0, 5)
+      [36mi[39m To remove this warning consider changing prior specification.
+    Output
+              prior     class coef group resp  dpar nlpar   lb   ub source
+       normal(0, 5) Intercept                             <NA> <NA>   user
+       normal(0, 5) Intercept                 sigma       <NA> <NA>   user
+
+# .replace_prior errors when passed a new prior without a match in old_prior [unicode]
+
+    Code
+      .replace_prior(old_prior, new_prior, warn = TRUE)
+    Condition
+      Warning:
+      ! One or more priors have no match in existing parameters:
+      Intercept_shape ~ normal(0, 5)
+      ℹ To remove this warning consider changing prior specification.
+    Output
+              prior     class coef group resp  dpar nlpar   lb   ub source
+       normal(0, 5) Intercept                             <NA> <NA>   user
+       normal(0, 5) Intercept                 sigma       <NA> <NA>   user
+
+# .replace_prior errors when passed a new prior without a match in old_prior [fancy]
+
+    Code
+      .replace_prior(old_prior, new_prior, warn = TRUE)
+    Condition
+      [1m[33mWarning[39m:[22m
+      [1m[22m[33m![39m One or more priors have no match in existing parameters:
+      Intercept_shape ~ normal(0, 5)
+      [36mℹ[39m To remove this warning consider changing prior specification.
+    Output
+              prior     class coef group resp  dpar nlpar   lb   ub source
+       normal(0, 5) Intercept                             <NA> <NA>   user
+       normal(0, 5) Intercept                 sigma       <NA> <NA>   user
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -17,13 +17,16 @@ test_that(".replace_prior successfully replaces priors", { # nolint: line_length
   expect_s3_class(prior, "data.frame")
 })
 
-test_that(".replace_prior errors when passed a new prior without a match in old_prior", { # nolint: line_length_linter.
+cli::test_that_cli(".replace_prior errors when passed a new prior without a match in old_prior", {
   old_prior <- brms::prior("normal(0, 10)", class = "Intercept") +
     brms::prior("normal(0, 10)", class = "Intercept", dpar = "sigma")
   new_prior <- brms::prior("normal(0, 5)", class = "Intercept") +
     brms::prior("normal(0, 5)", class = "Intercept", dpar = "sigma") +
     brms::prior("normal(0, 5)", class = "Intercept", dpar = "shape")
-  expect_warning(.replace_prior(old_prior, new_prior, warn = TRUE))
+  
+  expect_snapshot({
+    .replace_prior(old_prior, new_prior, warn = TRUE)
+  })
 })
 
 test_that(".add_dpar_info works as expected for the lognormal and gamma families", { # nolint: line_length_linter.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -17,13 +17,13 @@ test_that(".replace_prior successfully replaces priors", { # nolint: line_length
   expect_s3_class(prior, "data.frame")
 })
 
-cli::test_that_cli(".replace_prior errors when passed a new prior without a match in old_prior", {
+cli::test_that_cli(".replace_prior errors when passed a new prior without a match in old_prior", { # nolint: line_length_linter.
   old_prior <- brms::prior("normal(0, 10)", class = "Intercept") +
     brms::prior("normal(0, 10)", class = "Intercept", dpar = "sigma")
   new_prior <- brms::prior("normal(0, 5)", class = "Intercept") +
     brms::prior("normal(0, 5)", class = "Intercept", dpar = "sigma") +
     brms::prior("normal(0, 5)", class = "Intercept", dpar = "shape")
-  
+
   expect_snapshot({
     .replace_prior(old_prior, new_prior, warn = TRUE)
   })


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #194.

So far it adds a snapshot test for expecting a certain warning.

There are also lots of calls to `expect_error`. I wonder how they should be handled? New issue for this?

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
